### PR TITLE
Minor update to allow the global drupalSettings in ESLint.

### DIFF
--- a/source/.eslintrc
+++ b/source/.eslintrc
@@ -5,7 +5,8 @@
     "es6": true
   },
   "globals": {
-  	"module": true,
+    "drupalSettings": true,
+    "module": true,
     "ga": true,
     "GMaps": true,
     "google": true,


### PR DESCRIPTION
Minor fix for a slight annoyance for eslint. Make eslint aware of the global 'drupalSettings" object.