### PR TITLE
Fix Acquia's RA service from complaining about no composer.lock file.

### DIFF
--- a/.docksal/commands/init-project
+++ b/.docksal/commands/init-project
@@ -103,9 +103,10 @@ if [[ $BUILDER == "true" ]]; then
   rm -rf source
   rm -rf .gitignore
   rm -rf .travis.yml
-  # @note Don't remove composer.json file - Drush9 does not play well on Acquia if composer.json doesn't exist.
+  # @NOTE: Don't remove composer.json/composer.lock file -
+  #   Drush9 does not play well on Acquia if these files don't exist.
   # rm -rf composer.json
-  rm -rf composer.lock
+  # rm -rf composer.lock
   rm -rf LICENSE
   rm -rf package.json
   rm -rf phpunit.xml.dist


### PR DESCRIPTION
Running this drush comman:
`fin drush @www.remote_dev pm:security`

Produced an error of:
> In SecurityUpdateCommands.php line 110:
   Cannot find /mnt/www/html/upackd8dev/composer.lock!

Fix the init-projects command from removing the composer.lock file.